### PR TITLE
add pass-through attributes to link or js tags

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,10 +17,10 @@ module.exports = function (options) {
     xhtml: false
   };
   const merged = Object.assign(config, options);
-
   const mergedWithNormalizedPath = Object.assign(merged, {
     path: _normalizePath(merged.path),
   });
+  mergedWithNormalizedPath.passThroughAttributes = mergedWithNormalizedPath.passThroughAttributes || {};
 
   return through.obj(function (file, enc, cb) {
     if (file.isNull()) {
@@ -40,14 +40,18 @@ module.exports = function (options) {
     const htmlName = fileName + '.html';
     let includeContents;
     const normalizedPath = path.join(mergedWithNormalizedPath.path, fileName);
+    const passThroughAttributes = Object
+        .keys(mergedWithNormalizedPath.passThroughAttributes)
+        .map(attr => `${attr}="${options.passThroughAttributes[attr]}"`)
+        .join(' ');
 
     if (fileType === '.js') {
-      includeContents = `<script src="${normalizedPath}"></script>`;
+      includeContents = `<script src="${normalizedPath}" ${passThroughAttributes}></script>`;
     } else if (fileType === '.css') {
       if (mergedWithNormalizedPath.xhtml) {
-        includeContents = `<link href="${normalizedPath}" rel="stylesheet" />`;
+        includeContents = `<link href="${normalizedPath}" rel="stylesheet" ${passThroughAttributes}/>`;
       } else {
-        includeContents = `<link href="${normalizedPath}" rel="stylesheet">`;
+        includeContents = `<link href="${normalizedPath}" rel="stylesheet" ${passThroughAttributes}>`;
       }
     } else {
       this.push(file);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/gulp-html-include",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "license": "MIT",
   "description": "HTML include generator for static assets, e.g., foo.min.js => foo.min.js.html",
   "repository": {

--- a/test/index-spec.js
+++ b/test/index-spec.js
@@ -7,14 +7,18 @@ var path = require('path');
 
 var through = require('through2');
 
-var JS_INCLUDE = '<script src="include/path/javascript.js"></script>';
-var CSS_INCLUDE = '<link href="include/path/style.css" rel="stylesheet">';
+var JS_INCLUDE = '<script src="include/path/javascript.js" ></script>';
+var CSS_INCLUDE = '<link href="include/path/style.css" rel="stylesheet" >';
 var CSS_INCLUDE_XHTML = '<link href="include/path/style.css" rel="stylesheet" />';
-var JS_ROOT = '<script src="/javascript.js"></script>';
-var CSS_ROOT = '<link href="/style.css" rel="stylesheet">';
+var JS_ROOT = '<script src="/javascript.js" ></script>';
+var CSS_ROOT = '<link href="/style.css" rel="stylesheet" >';
 var CSS_ROOT_XHTML = '<link href="/style.css" rel="stylesheet" />';
 var DEFAULT_JS_DEST = 'javascript.js.html';
 var DEFAULT_CSS_DEST = 'style.css.html';
+var LITERAL_ATTRIBUTES = {'back to school': 1986};
+var JS_ROOT_WITH_LITERAL_ATTRIBUTES = '<script src="/javascript.js" back to school="1986"></script>';
+var CSS_ROOT_WITH_LITERAL_ATTRIBUTES = '<link href="/style.css" rel="stylesheet" back to school="1986">';
+var CSS_ROOT_XHTML_WITH_LITERAL_ATTRIBUTES = '<link href="/style.css" rel="stylesheet" back to school="1986"/>';
 
 var out = gutil.log;
 
@@ -208,4 +212,49 @@ describe('Output Destinations', function () {
     }));
   });
 
+});
+
+describe('Literal attributes', function () {
+
+  it('should pass literal attributes to js tags', function (done) {
+    var stream = include({passThroughAttributes: LITERAL_ATTRIBUTES});
+
+    stream.on('data', function (file) {
+      expect(file.contents.toString()).to.equal(JS_ROOT_WITH_LITERAL_ATTRIBUTES);
+      done();
+    });
+
+    stream.write(new gutil.File({
+      path: 'javascript.js',
+      contents: Buffer.from('')
+    }));
+  });
+
+  it('should pass literal attributes to style tags', function (done) {
+    var stream = include({passThroughAttributes: LITERAL_ATTRIBUTES});
+
+    stream.on('data', function (file) {
+      expect(file.contents.toString()).to.equal(CSS_ROOT_WITH_LITERAL_ATTRIBUTES);
+      done();
+    });
+
+    stream.write(new gutil.File({
+      path: 'style.css',
+      contents: Buffer.from('')
+    }));
+  });
+
+  it('should pass literal attributes to xhtml style tags', function (done) {
+    var stream = include({passThroughAttributes: LITERAL_ATTRIBUTES, xhtml: true});
+
+    stream.on('data', function (file) {
+      expect(file.contents.toString()).to.equal(CSS_ROOT_XHTML_WITH_LITERAL_ATTRIBUTES);
+      done();
+    });
+
+    stream.write(new gutil.File({
+      path: 'style.css',
+      contents: Buffer.from('')
+    }));
+  });
 });


### PR DESCRIPTION
added feature of passing in pass-through-attributes to link or js tags. this opens up possibilities for defer, async, and de-prioritized css with use of media and onload attributes